### PR TITLE
Bug fix: Add conversion method for Dense/Sparse Hamiltonian

### DIFF
--- a/src/hamiltonian/adiabatic_frame_hamiltonian.jl
+++ b/src/hamiltonian/adiabatic_frame_hamiltonian.jl
@@ -81,32 +81,6 @@ end
 
 
 function (h::AdiabaticFrameHamiltonian)(
-    du::Vector{T},
-    u::Vector{T},
-    tf::Real,
-    t::Real
-) where T
-    ω = h.diagonal(t)
-    du .= -2.0im * π * tf * ω * u
-    G = h.geometric(t)
-    du .+= -1.0im * G * u
-end
-
-
-function (h::AdiabaticFrameHamiltonian)(
-    du::Vector{T},
-    u::Vector{T},
-    tf::UnitTime,
-    t::Real
-) where T <: Number
-    ω = h.diagonal(t / tf)
-    du .= -2.0im * π * ω * u
-    G = h.geometric(t / tf)
-    du .+= -1.0im / tf * G * u
-end
-
-
-function (h::AdiabaticFrameHamiltonian)(
     du::Matrix{T},
     u::Matrix{T},
     tf::Real,
@@ -191,4 +165,31 @@ function (G::GeometricOperator)(t)
         end
     end
     Hermitian(G.u_cache, :L)
+end
+
+
+#TODO The following functions will be deprecated
+function (h::AdiabaticFrameHamiltonian)(
+    du::Vector{T},
+    u::Vector{T},
+    tf::Real,
+    t::Real
+) where T
+    ω = h.diagonal(t)
+    du .= -2.0im * π * tf * ω * u
+    G = h.geometric(t)
+    du .+= -1.0im * G * u
+end
+
+
+function (h::AdiabaticFrameHamiltonian)(
+    du::Vector{T},
+    u::Vector{T},
+    tf::UnitTime,
+    t::Real
+) where T <: Number
+    ω = h.diagonal(t / tf)
+    du .= -2.0im * π * ω * u
+    G = h.geometric(t / tf)
+    du .+= -1.0im / tf * G * u
 end

--- a/src/hamiltonian/sparse_hamiltonian.jl
+++ b/src/hamiltonian/sparse_hamiltonian.jl
@@ -29,7 +29,7 @@ function SparseHamiltonian(funcs, mats; unit=:h)
         throw(ArgumentError("Matrices in the list do not have the same size."))
     end
     cache = similar(sum(mats))
-    fill!(cache, 0.0 + 0.0im)
+    fill!(cache, 0.0)
     SparseHamiltonian(funcs, unit_scale(unit)*mats, cache, size(mats[1]))
 end
 

--- a/src/hamiltonian/util.jl
+++ b/src/hamiltonian/util.jl
@@ -55,9 +55,10 @@ function to_real(H::DenseHamiltonian{T}) where {T<:Complex}
     DenseHamiltonian(H.f, m_real)
 end
 
-function to_real(H::SparseHamiltonian{T}) where {T<:Complex}
-    m_real = [real(x) for x in H.m]
-    SparseHamiltonian(H.f, m_real)
+
+function Base.real(H::AbstractHamiltonian{T}) where T
+    S = real(T)
+    convert(S, H)
 end
 
 

--- a/src/hamiltonian/util.jl
+++ b/src/hamiltonian/util.jl
@@ -1,13 +1,12 @@
-Base.summary(H::AbstractHamiltonian) =
-    string(
-        TYPE_COLOR,
-        nameof(typeof(H)),
-        NO_COLOR,
-        " with ",
-        TYPE_COLOR,
-        typeof(H).parameters[1],
-        NO_COLOR
-    )
+Base.summary(H::AbstractHamiltonian) = string(
+    TYPE_COLOR,
+    nameof(typeof(H)),
+    NO_COLOR,
+    " with ",
+    TYPE_COLOR,
+    typeof(H).parameters[1],
+    NO_COLOR,
+)
 
 function Base.show(io::IO, A::AbstractHamiltonian)
     println(io, summary(A))
@@ -51,12 +50,21 @@ end
 
 Convert a Hamiltonian with Complex type to a Hamiltonian with real type. The converted Hamiltonian is used for projection to low-level subspaces and should not be used for any ODE calculations.
 """
-function to_real(H::DenseHamiltonian{T}) where T<:Complex
+function to_real(H::DenseHamiltonian{T}) where {T<:Complex}
     m_real = [real(x) for x in H.m]
     DenseHamiltonian(H.f, m_real)
 end
 
-function to_real(H::SparseHamiltonian{T}) where T<:Complex
+function to_real(H::SparseHamiltonian{T}) where {T<:Complex}
     m_real = [real(x) for x in H.m]
     SparseHamiltonian(H.f, m_real)
+end
+
+
+function is_complex(f_list, m_list)
+    any(m_list) do m
+        eltype(m) <: Complex
+    end || any(f_list) do f
+        typeof(f(0)) <: Complex
+    end
 end

--- a/src/projection/projection.jl
+++ b/src/projection/projection.jl
@@ -145,7 +145,7 @@ function project_to_lowlevel(
     ref = zeros((0, 2)), tol = 1e-4, lvl = 2
 ) where T <: Complex
     @warn "The projection method only works with real Hamitonians. Convert the complex Hamiltonian to real one."
-    H_real = to_real(H)
+    H_real = real(H)
     project_to_lowlevel(
         H_real,
         dH,

--- a/test/hamiltonian/sparse_hamiltonian.jl
+++ b/test/hamiltonian/sparse_hamiltonian.jl
@@ -8,6 +8,10 @@ u = [1.0 + 0.0im, 1] / sqrt(2)
 
 H_sparse = SparseHamiltonian([A, B], [spσx, spσz])
 
+H_real = real(H_sparse)
+@test eltype(H_real) <: Real
+@test H_sparse(0.0) ≈ H_real(0.0)
+
 @test size(H_sparse) == (2,2)
 @test is_sparse(H_sparse)
 @test H_sparse(0) ≈ 2π * spσx

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -2,13 +2,13 @@ using QTBase, Test
 
 
 H = DenseHamiltonian([(s)->1-s, (s)->s], [σx, σz])
-dH(s) = (-real(σx) + real(σz))*2*π
+dH(s) = (-real(σx) + real(σz))
 coupling = ConstantCouplings(["Z"])
 
 t_obj = project_to_lowlevel(H, dH, coupling, [0.0, 0.5, 1.0])
 
 @test isapprox(
-    t_obj.ev ./ 2 ./ π,
+    t_obj.ev,
     [[-1.0, 1.0], [-0.707107, 0.707107], [-1.0, 1.0]],
     atol = 1e-6
 )
@@ -32,7 +32,7 @@ coupling = ConstantCouplings(["ZI", "IZ"])
 t_obj = project_to_lowlevel(H, dH, coupling, [0.0, 0.5, 1.0])
 
 @test isapprox(
-    t_obj.ev ./ π,
-    [[-2.0, 0.0], [-1.2088723439378917, -0.20887234393789134], [-1.1, -0.9]],
+    t_obj.ev,
+    [[-1.0, 0.0], [-0.6044361719689455, -0.10443617196894575], [-0.55, -0.45]],
     atol = 1e-6
 )


### PR DESCRIPTION
Now the code will go over the entire list of functions and matrices to check the number type when constructing Dense/Sparse Hamiltonian. 